### PR TITLE
Modernize starter kit

### DIFF
--- a/fastly.toml
+++ b/fastly.toml
@@ -4,6 +4,9 @@ language = "javascript"
 manifest_version = 2
 name = "Queuing / Waiting room (JS)"
 
+[scripts]
+  build = "npm run build"
+
 [local_server]
 
   [local_server.backends]

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,19 +9,120 @@
       "version": "1.0.0-pre",
       "license": "MIT",
       "dependencies": {
-        "@fastly/js-compute": "^1.3.1",
+        "@fastly/js-compute": "^1.5.1",
         "@upstash/redis": "^1.19.3",
         "jws": "^4.0.0"
       },
       "devDependencies": {
         "buffer": "^6.0.3",
-        "core-js": "^3.27.2",
         "node-polyfill-webpack-plugin": "^2.0.1",
-        "webpack": "^5.75.0",
+        "webpack": "^5.76.2",
         "webpack-cli": "^5.0.1"
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/regjsgen": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@babel/regjsgen/-/regjsgen-0.8.0.tgz",
+      "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
+    },
+    "node_modules/@bytecodealliance/componentize-js": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/componentize-js/-/componentize-js-0.0.1.tgz",
+      "integrity": "sha512-sfQwMMfWZcMJ70cdMm0QnasTTXRM/LGgEzTeBbHPnJE/YQpqMEi4TsjbyGCVV9GLzMC0mRfS8aX8vlkYVhwJcw==",
+      "dependencies": {
+        "@bytecodealliance/jco": "^0.4.0",
+        "@jakechampion/wizer": "^1.6.0"
+      }
+    },
+    "node_modules/@bytecodealliance/jco": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/jco/-/jco-0.4.2.tgz",
+      "integrity": "sha512-adeezw3wQhuGzEUcc4fZ/Vm9rn7Yp1p+0fbgg7TWfNuVrgbwMN3Me2BVAQqEwfKf3x/jfgbU1D0neFsu83eqYQ==",
+      "dependencies": {
+        "@bytecodealliance/componentize-js": "^0.0.1"
+      },
+      "bin": {
+        "jco": "cli.mjs"
+      }
+    },
+    "node_modules/@bytecodealliance/wizer": {
+      "version": "1.6.1-beta.4",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer/-/wizer-1.6.1-beta.4.tgz",
+      "integrity": "sha512-afgV4lyYVMBN/9/yNDgYGTn92D7VrqS0yTZ3WZgDyDTiOWjmSuQimEiX+VzCiYjF9GXsKwzCY1FEOu1pY2Evgw==",
+      "bin": {
+        "wizer": "wizer.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@bytecodealliance/wizer-darwin-arm64": "1.6.1-beta.4",
+        "@bytecodealliance/wizer-darwin-x64": "1.6.1-beta.4",
+        "@bytecodealliance/wizer-linux-x64": "1.6.1-beta.4",
+        "@bytecodealliance/wizer-win32-x64": "1.6.1-beta.4"
+      }
+    },
+    "node_modules/@bytecodealliance/wizer-darwin-arm64": {
+      "version": "1.6.1-beta.4",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-darwin-arm64/-/wizer-darwin-arm64-1.6.1-beta.4.tgz",
+      "integrity": "sha512-NyleEH0GKBqS0DCuKceY3a2ZxF/aNzYa68swbKKljSFh6uo/3Cqr/U5/SuTxval6/VwtZ1eEzRPaLbLlUE5r4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "wizer-darwin-arm64": "wizer"
+      }
+    },
+    "node_modules/@bytecodealliance/wizer-darwin-x64": {
+      "version": "1.6.1-beta.4",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-darwin-x64/-/wizer-darwin-x64-1.6.1-beta.4.tgz",
+      "integrity": "sha512-2s8HPLrttAyYUJNHQlLVi3rDGlnk9IzEJTbw0DApfpVnCZZ1aTLt6MXTIBeOYo9si5Q4cqyDHT5bAoNZvJTk9A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "wizer-darwin-x64": "wizer"
+      }
+    },
+    "node_modules/@bytecodealliance/wizer-linux-x64": {
+      "version": "1.6.1-beta.4",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-linux-x64/-/wizer-linux-x64-1.6.1-beta.4.tgz",
+      "integrity": "sha512-S+oYRGGveuPLtiI6V7SQpZHhw43asLArC+fGrJRQ3OsHs8aj/IVusRLVYgWfKw1HtZm9iIWrjH9WYO6BWak4eQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "wizer-linux-x64": "wizer"
+      }
+    },
+    "node_modules/@bytecodealliance/wizer-win32-x64": {
+      "version": "1.6.1-beta.4",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-win32-x64/-/wizer-win32-x64-1.6.1-beta.4.tgz",
+      "integrity": "sha512-NxqrLqFnaMyldkN7lBVS+Em23f84/RKrHjBXt9WnZK2RtJjvwoCXr+so6+qfj4f1K9BhIZ8UaBfYwqPvtLOcZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "wizer-win32-x64": "wizer"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -64,13 +165,14 @@
       }
     },
     "node_modules/@fastly/js-compute": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@fastly/js-compute/-/js-compute-1.3.1.tgz",
-      "integrity": "sha512-8+3TxTYaiOU2VAyt5GwsfVWgXkKtZqlQ7CO56f10Lw53aL7PkVfDlmPrxBWdLPTW/DFoZwYDnJqRLRrCXA5QdA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@fastly/js-compute/-/js-compute-1.5.1.tgz",
+      "integrity": "sha512-PXTZtB4cQziFyOs4KPpZ9ZW6sOOYv2PslXH9HVPDkDCo+G+Q+HcnKKc1giGPGR/NipqVkCugkaNynaVHMCrijw==",
       "dependencies": {
-        "@jakechampion/wizer": "^1.6.0",
+        "@bytecodealliance/jco": "^0.4.1",
+        "@bytecodealliance/wizer": "^1.6.1-beta.4",
         "esbuild": "^0.15.16",
-        "js-component-tools": "0.2.2",
+        "regexpu-core": "^5.3.1",
         "tree-sitter": "^0.20.1",
         "tree-sitter-javascript": "^0.19.0"
       },
@@ -78,8 +180,8 @@
         "js-compute-runtime": "js-compute-runtime-cli.js"
       },
       "engines": {
-        "node": "16 - 18",
-        "npm": "^8"
+        "node": "16 - 19",
+        "npm": "^8 || ^9"
       }
     },
     "node_modules/@jakechampion/wizer": {
@@ -929,17 +1031,6 @@
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==",
       "dev": true
-    },
-    "node_modules/core-js": {
-      "version": "3.27.2",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.27.2.tgz",
-      "integrity": "sha512-9ashVQskuh5AZEZ1JdQWp1GqSoC1e1G87MzRqg2gIfVAQ7Qn9K+uFj8EcniUFA4P2NLZfV+TOlX1SzoKfo+s7w==",
-      "dev": true,
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -2073,12 +2164,12 @@
         "node": ">= 10.13.0"
       }
     },
-    "node_modules/js-component-tools": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/js-component-tools/-/js-component-tools-0.2.2.tgz",
-      "integrity": "sha512-+DorgW2JyOf3Qja35wtw0VQYkcdo4tkInapJ4xlPJXXW49RhEdNMzX/PoHKC5nS7AhV1VBweA1gmYOIYUOXDLw==",
+    "node_modules/jsesc": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==",
       "bin": {
-        "jsct": "cli.mjs"
+        "jsesc": "bin/jsesc"
       }
     },
     "node_modules/json-parse-even-better-errors": {
@@ -2693,6 +2784,49 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/regenerate": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A=="
+    },
+    "node_modules/regenerate-unicode-properties": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.1.0.tgz",
+      "integrity": "sha512-d1VudCLoIGitcU/hEg2QqvyGZQmdC0Lf8BqdOMXGFSvJP4bNV1+XqbPQeHHLD51Jh4QJJ225dlIFvY4Ly6MXmQ==",
+      "dependencies": {
+        "regenerate": "^1.4.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/regexpu-core": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.3.2.tgz",
+      "integrity": "sha512-RAM5FlZz+Lhmo7db9L298p2vHP5ZywrVXmVXpmAD9GuL5MPH6t9ROw1iA/wfHkQ76Qe7AaPF0nGuim96/IrQMQ==",
+      "dependencies": {
+        "@babel/regjsgen": "^0.8.0",
+        "regenerate": "^1.4.2",
+        "regenerate-unicode-properties": "^10.1.0",
+        "regjsparser": "^0.9.1",
+        "unicode-match-property-ecmascript": "^2.0.0",
+        "unicode-match-property-value-ecmascript": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/regjsparser": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.9.1.tgz",
+      "integrity": "sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==",
+      "dependencies": {
+        "jsesc": "~0.5.0"
+      },
+      "bin": {
+        "regjsparser": "bin/parser"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -3198,6 +3332,42 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/unicode-canonical-property-names-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-match-property-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
+      "dependencies": {
+        "unicode-canonical-property-names-ecmascript": "^2.0.0",
+        "unicode-property-aliases-ecmascript": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-match-property-value-ecmascript": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.1.0.tgz",
+      "integrity": "sha512-qxkjQt6qjg/mYscYMC0XKRn3Rh0wFPlfxB0xkt9CfyTvpX1Ra0+rAmdX2QyAobptSEvuy4RtpPRui6XkV+8wjA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/unicode-property-aliases-ecmascript": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
+      "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
@@ -3292,9 +3462,9 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.76.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.2.tgz",
+      "integrity": "sha512-Th05ggRm23rVzEOlX8y67NkYCHa9nTNcwHPBhdg+lKG+mtiW7XgggjAeeLnADAe7mLjJ6LUNfgHAuRRh+Z6J7w==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
@@ -3493,6 +3663,63 @@
     }
   },
   "dependencies": {
+    "@babel/regjsgen": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@babel/regjsgen/-/regjsgen-0.8.0.tgz",
+      "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
+    },
+    "@bytecodealliance/componentize-js": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/componentize-js/-/componentize-js-0.0.1.tgz",
+      "integrity": "sha512-sfQwMMfWZcMJ70cdMm0QnasTTXRM/LGgEzTeBbHPnJE/YQpqMEi4TsjbyGCVV9GLzMC0mRfS8aX8vlkYVhwJcw==",
+      "requires": {
+        "@bytecodealliance/jco": "^0.4.0",
+        "@jakechampion/wizer": "^1.6.0"
+      }
+    },
+    "@bytecodealliance/jco": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/jco/-/jco-0.4.2.tgz",
+      "integrity": "sha512-adeezw3wQhuGzEUcc4fZ/Vm9rn7Yp1p+0fbgg7TWfNuVrgbwMN3Me2BVAQqEwfKf3x/jfgbU1D0neFsu83eqYQ==",
+      "requires": {
+        "@bytecodealliance/componentize-js": "^0.0.1"
+      }
+    },
+    "@bytecodealliance/wizer": {
+      "version": "1.6.1-beta.4",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer/-/wizer-1.6.1-beta.4.tgz",
+      "integrity": "sha512-afgV4lyYVMBN/9/yNDgYGTn92D7VrqS0yTZ3WZgDyDTiOWjmSuQimEiX+VzCiYjF9GXsKwzCY1FEOu1pY2Evgw==",
+      "requires": {
+        "@bytecodealliance/wizer-darwin-arm64": "1.6.1-beta.4",
+        "@bytecodealliance/wizer-darwin-x64": "1.6.1-beta.4",
+        "@bytecodealliance/wizer-linux-x64": "1.6.1-beta.4",
+        "@bytecodealliance/wizer-win32-x64": "1.6.1-beta.4"
+      }
+    },
+    "@bytecodealliance/wizer-darwin-arm64": {
+      "version": "1.6.1-beta.4",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-darwin-arm64/-/wizer-darwin-arm64-1.6.1-beta.4.tgz",
+      "integrity": "sha512-NyleEH0GKBqS0DCuKceY3a2ZxF/aNzYa68swbKKljSFh6uo/3Cqr/U5/SuTxval6/VwtZ1eEzRPaLbLlUE5r4w==",
+      "optional": true
+    },
+    "@bytecodealliance/wizer-darwin-x64": {
+      "version": "1.6.1-beta.4",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-darwin-x64/-/wizer-darwin-x64-1.6.1-beta.4.tgz",
+      "integrity": "sha512-2s8HPLrttAyYUJNHQlLVi3rDGlnk9IzEJTbw0DApfpVnCZZ1aTLt6MXTIBeOYo9si5Q4cqyDHT5bAoNZvJTk9A==",
+      "optional": true
+    },
+    "@bytecodealliance/wizer-linux-x64": {
+      "version": "1.6.1-beta.4",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-linux-x64/-/wizer-linux-x64-1.6.1-beta.4.tgz",
+      "integrity": "sha512-S+oYRGGveuPLtiI6V7SQpZHhw43asLArC+fGrJRQ3OsHs8aj/IVusRLVYgWfKw1HtZm9iIWrjH9WYO6BWak4eQ==",
+      "optional": true
+    },
+    "@bytecodealliance/wizer-win32-x64": {
+      "version": "1.6.1-beta.4",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/wizer-win32-x64/-/wizer-win32-x64-1.6.1-beta.4.tgz",
+      "integrity": "sha512-NxqrLqFnaMyldkN7lBVS+Em23f84/RKrHjBXt9WnZK2RtJjvwoCXr+so6+qfj4f1K9BhIZ8UaBfYwqPvtLOcZQ==",
+      "optional": true
+    },
     "@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -3512,13 +3739,14 @@
       "optional": true
     },
     "@fastly/js-compute": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@fastly/js-compute/-/js-compute-1.3.1.tgz",
-      "integrity": "sha512-8+3TxTYaiOU2VAyt5GwsfVWgXkKtZqlQ7CO56f10Lw53aL7PkVfDlmPrxBWdLPTW/DFoZwYDnJqRLRrCXA5QdA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@fastly/js-compute/-/js-compute-1.5.1.tgz",
+      "integrity": "sha512-PXTZtB4cQziFyOs4KPpZ9ZW6sOOYv2PslXH9HVPDkDCo+G+Q+HcnKKc1giGPGR/NipqVkCugkaNynaVHMCrijw==",
       "requires": {
-        "@jakechampion/wizer": "^1.6.0",
+        "@bytecodealliance/jco": "^0.4.1",
+        "@bytecodealliance/wizer": "^1.6.1-beta.4",
         "esbuild": "^0.15.16",
-        "js-component-tools": "0.2.2",
+        "regexpu-core": "^5.3.1",
         "tree-sitter": "^0.20.1",
         "tree-sitter-javascript": "^0.19.0"
       }
@@ -4189,12 +4417,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
       "integrity": "sha512-xFxOwqIzR/e1k1gLiWEophSCMqXcwVHIH7akf7b/vxcUeGunlj3hvZaaqxwHsTgn+IndtkQJgSztIDWeumWJDQ==",
-      "dev": true
-    },
-    "core-js": {
-      "version": "3.27.2",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.27.2.tgz",
-      "integrity": "sha512-9ashVQskuh5AZEZ1JdQWp1GqSoC1e1G87MzRqg2gIfVAQ7Qn9K+uFj8EcniUFA4P2NLZfV+TOlX1SzoKfo+s7w==",
       "dev": true
     },
     "core-util-is": {
@@ -4976,10 +5198,10 @@
         "supports-color": "^8.0.0"
       }
     },
-    "js-component-tools": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/js-component-tools/-/js-component-tools-0.2.2.tgz",
-      "integrity": "sha512-+DorgW2JyOf3Qja35wtw0VQYkcdo4tkInapJ4xlPJXXW49RhEdNMzX/PoHKC5nS7AhV1VBweA1gmYOIYUOXDLw=="
+    "jsesc": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+      "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA=="
     },
     "json-parse-even-better-errors": {
       "version": "2.3.1",
@@ -5490,6 +5712,40 @@
         "resolve": "^1.20.0"
       }
     },
+    "regenerate": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A=="
+    },
+    "regenerate-unicode-properties": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.1.0.tgz",
+      "integrity": "sha512-d1VudCLoIGitcU/hEg2QqvyGZQmdC0Lf8BqdOMXGFSvJP4bNV1+XqbPQeHHLD51Jh4QJJ225dlIFvY4Ly6MXmQ==",
+      "requires": {
+        "regenerate": "^1.4.2"
+      }
+    },
+    "regexpu-core": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.3.2.tgz",
+      "integrity": "sha512-RAM5FlZz+Lhmo7db9L298p2vHP5ZywrVXmVXpmAD9GuL5MPH6t9ROw1iA/wfHkQ76Qe7AaPF0nGuim96/IrQMQ==",
+      "requires": {
+        "@babel/regjsgen": "^0.8.0",
+        "regenerate": "^1.4.2",
+        "regenerate-unicode-properties": "^10.1.0",
+        "regjsparser": "^0.9.1",
+        "unicode-match-property-ecmascript": "^2.0.0",
+        "unicode-match-property-value-ecmascript": "^2.1.0"
+      }
+    },
+    "regjsparser": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.9.1.tgz",
+      "integrity": "sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==",
+      "requires": {
+        "jsesc": "~0.5.0"
+      }
+    },
     "resolve": {
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -5861,6 +6117,30 @@
       "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
       "dev": true
     },
+    "unicode-canonical-property-names-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ=="
+    },
+    "unicode-match-property-ecmascript": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+      "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
+      "requires": {
+        "unicode-canonical-property-names-ecmascript": "^2.0.0",
+        "unicode-property-aliases-ecmascript": "^2.0.0"
+      }
+    },
+    "unicode-match-property-value-ecmascript": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.1.0.tgz",
+      "integrity": "sha512-qxkjQt6qjg/mYscYMC0XKRn3Rh0wFPlfxB0xkt9CfyTvpX1Ra0+rAmdX2QyAobptSEvuy4RtpPRui6XkV+8wjA=="
+    },
+    "unicode-property-aliases-ecmascript": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
+      "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w=="
+    },
     "update-browserslist-db": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
@@ -5938,9 +6218,9 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "webpack": {
-      "version": "5.75.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.75.0.tgz",
-      "integrity": "sha512-piaIaoVJlqMsPtX/+3KTTO6jfvrSYgauFVdt8cr9LTHKmcq/AMd4mhzsiP7ZF/PGRNPGA8336jldh9l2Kt2ogQ==",
+      "version": "5.76.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.2.tgz",
+      "integrity": "sha512-Th05ggRm23rVzEOlX8y67NkYCHa9nTNcwHPBhdg+lKG+mtiW7XgggjAeeLnADAe7mLjJ6LUNfgHAuRRh+Z6J7w==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",

--- a/package.json
+++ b/package.json
@@ -4,15 +4,14 @@
     "url": "https://github.com/fastly/compute-starter-kit-javascript-queue/issues"
   },
   "dependencies": {
-    "@fastly/js-compute": "^1.3.1",
+    "@fastly/js-compute": "^1.5.1",
     "@upstash/redis": "^1.19.3",
     "jws": "^4.0.0"
   },
   "devDependencies": {
     "buffer": "^6.0.3",
-    "core-js": "^3.27.2",
     "node-polyfill-webpack-plugin": "^2.0.1",
-    "webpack": "^5.75.0",
+    "webpack": "^5.76.2",
     "webpack-cli": "^5.0.1"
   },
   "engines": {
@@ -27,9 +26,9 @@
     "url": "git+https://github.com/fastly/compute-starter-kit-javascript-queue.git"
   },
   "scripts": {
+    "prebuild": "webpack",
     "build": "js-compute-runtime bin/index.js bin/main.wasm",
-    "deploy": "npm run build && fastly compute deploy",
-    "prebuild": "webpack"
+    "deploy": "fastly compute publish"
   },
   "version": "1.0.0-pre"
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 
 /// <reference types="@fastly/js-compute" />
 
+import { includeBytes } from "fastly:experimental";
 import * as jws from "jws";
 
 import fetchConfig from "./config";
@@ -21,12 +22,14 @@ import log from "./logging";
 
 import processView from "./views";
 
-import adminView from "./views/admin.html";
-import queueView from "./views/queue.html";
+const textDecoder = new TextDecoder();
+
+const adminView = textDecoder.decode(includeBytes('src/views/admin.html'));
+const queueView = textDecoder.decode(includeBytes('src/views/queue.html'));
 
 // For demo purposes
-import demoManifest from "./static/demo-manifest.md";
-const DEMO_THUMBNAIL = fastly.includeBytes('src/static/demo-thumb.png');
+const demoManifest = textDecoder.decode(includeBytes('src/static/demo-manifest.md'));
+const DEMO_THUMBNAIL = includeBytes('src/static/demo-thumb.png');
 
 // The name of the backend serving the content that is being protected by the queue.
 const CONTENT_BACKEND = "protected_content";

--- a/src/views.js
+++ b/src/views.js
@@ -1,4 +1,7 @@
-import styles from "./static/style.css";
+import { includeBytes } from "fastly:experimental";
+
+const textDecoder = new TextDecoder();
+const styles = textDecoder.decode(includeBytes('src/static/style.css'));
 
 // Injects styles and props into the given template.
 export default function processView(template, props) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,11 +1,10 @@
 const path = require("path");
-const webpack = require("webpack");
 const NodePolyfillPlugin = require("node-polyfill-webpack-plugin");
 
 module.exports = {
   entry: "./src/index.js",
   optimization: {
-    minimize: false,
+    minimize: true,
   },
   target: "webworker",
   output: {
@@ -14,20 +13,25 @@ module.exports = {
     libraryTarget: "this",
   },
   module: {
-    // Asset modules are modules that allow the use asset files (fonts, icons, etc)
-    // without additional configuration or dependencies.
-    rules: [
-      // asset/source exports the source code of the asset.
-      // Usage: e.g., import notFoundPage from "./page_404.html"
-      {
-        test: /\.(txt|html|css|svg|md)/,
-        type: "asset/source",
-      },
-    ],
+    // Loaders go here.
+    // e.g., ts-loader for TypeScript
+    // rules: [
+    // ],
   },
   plugins: [
+    // Polyfills go here.
+    // Used for, e.g., any cross-platform WHATWG,
+    // or core nodejs modules needed for your application.
     new NodePolyfillPlugin({
       excludeAliases: ["console"],
     }),
+  ],
+  externals: [
+    ({request,}, callback) => {
+      if (/^fastly:.*$/.test(request)) {
+        return callback(null, 'commonjs ' + request);
+      }
+      callback();
+    }
   ],
 };


### PR DESCRIPTION
This PR makes some changes for modernizing the starter kit

* Uses `includeBytes` instead of Webpack asset modules
* Update dependencies