### PR TITLE
Use @fastly/cli in the starter kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ Park website visitors in a virtual queue to reduce the demand on your origins du
 ## Getting started
 
 1. If you haven't already, [sign up for Upstash](https://www.npmjs.com/package/@upstash/redis) and create a Redis service.
-2. Initialize a Compute project using this starter kit.
+2. Create a new directory for your application and switch to it. Initialize a Compute project using this starter kit.
    ```sh
-   fastly compute init --from=https://github.com/fastly/compute-starter-kit-javascript-queue
+   npm create @fastly/compute@latest -- --language=javascript --starter-kit=queue
    ```
 3. Create the `upstash` backend, changing the default hostname to the one provided in the Upstash console.
 4. Create the `protected_content` backend by accepting the default example host or setting your own.
 5. Populate the `config` config store by following the prompts to configure Upstash and set a secret for signing cookies.
-6. Run `fastly compute publish` to deploy your queue.
+6. Run `npm run deploy` to deploy your queue to your Fastly account.
 
 ## Understanding the code
 

--- a/fastly.toml
+++ b/fastly.toml
@@ -6,6 +6,7 @@ name = "Queuing / Waiting room (JS)"
 
 [scripts]
   build = "npm run build"
+  post_init = "npm install"
 
 [local_server]
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "jws": "^4.0.0"
   },
   "devDependencies": {
+    "@fastly/cli": "^10.14.0",
     "buffer": "^6.0.3",
     "node-polyfill-webpack-plugin": "^2.0.1",
     "webpack": "^5.89.0",
@@ -28,6 +29,7 @@
   "scripts": {
     "prebuild": "webpack",
     "build": "js-compute-runtime bin/index.js bin/main.wasm",
+    "start": "fastly compute serve",
     "deploy": "fastly compute publish"
   },
   "version": "1.0.0-pre"


### PR DESCRIPTION
This PR makes changes:

* Changes to **package.json** to enable usage without a global installation of the Fastly CLI:
   * Adds `@fastly/cli` to `devDependencies` so that it's available when using the starter kit, as a tool used to build and run or publish the application.
   * Makes sure that `scripts` contains `start` and `deploy` scripts as applicable.

* Adds instructions to the README describing how to initialize an application using the starter kit, as well as how to run it locally or publish it to a Fastly service, as applicable.

* Adds `post_init` script to run `npm install` if it was not present.