### PR TITLE
Consistent package.json

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '20.11'
       - name: Setup Fastly CLI
         uses: fastly/compute-actions/setup@v5
       - name: Install Dependencies

--- a/package.json
+++ b/package.json
@@ -1,36 +1,22 @@
 {
-  "author": "oss@fastly.com",
-  "bugs": {
-    "url": "https://github.com/fastly/compute-starter-kit-javascript-queue/issues"
-  },
+  "type": "commonjs",
+  "private": true,
   "dependencies": {
-    "@fastly/js-compute": "^3.0.0",
+    "@fastly/js-compute": "^3.33.2",
     "@upstash/redis": "^1.23.4",
     "jws": "^4.0.0"
   },
   "devDependencies": {
-    "@fastly/cli": "^10.14.0",
+    "@fastly/cli": "^11.0.0",
     "buffer": "^6.0.3",
     "node-polyfill-webpack-plugin": "^2.0.1",
-    "webpack": "^5.89.0",
+    "webpack": "^5.98.0",
     "webpack-cli": "^5.1.4"
-  },
-  "engines": {
-    "node": "^18.0.0"
-  },
-  "homepage": "https://developer.fastly.com/solutions/starters/compute-starter-kit-javascript-queue",
-  "license": "MIT",
-  "main": "src/index.js",
-  "name": "compute-starter-kit-javascript-queue",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/fastly/compute-starter-kit-javascript-queue.git"
   },
   "scripts": {
     "prebuild": "webpack",
     "build": "js-compute-runtime bin/index.js bin/main.wasm",
     "start": "fastly compute serve",
     "deploy": "fastly compute publish"
-  },
-  "version": "1.0.0-pre"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "type": "commonjs",
+  "type": "module",
   "private": true,
   "dependencies": {
     "@fastly/js-compute": "^3.33.2",
@@ -15,8 +15,11 @@
   },
   "scripts": {
     "prebuild": "webpack",
-    "build": "js-compute-runtime bin/index.js bin/main.wasm",
+    "build": "js-compute-runtime bin/index.cjs bin/main.wasm",
     "start": "fastly compute serve",
     "deploy": "fastly compute publish"
+  },
+  "engines": {
+    "node": ">= 20.11"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -5,9 +5,9 @@
 import { includeBytes } from "fastly:experimental";
 import * as jws from "jws";
 
-import fetchConfig from "./config";
+import fetchConfig from "./config.js";
 
-import { getQueueCookie, setQueueCookie } from "./cookies";
+import { getQueueCookie, setQueueCookie } from "./cookies.js";
 
 import {
   getStore,
@@ -16,11 +16,11 @@ import {
   incrementQueueCursor,
   incrementQueueLength,
   incrementAutoPeriod,
-} from "./store";
+} from "./store.js";
 
-import log from "./logging";
+import log from "./logging.js";
 
-import processView from "./views";
+import processView from "./views.js";
 
 const textDecoder = new TextDecoder();
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,16 +1,19 @@
-const path = require("path");
-const NodePolyfillPlugin = require("node-polyfill-webpack-plugin");
+import path from "path";
+import NodePolyfillPlugin from "node-polyfill-webpack-plugin";
 
-module.exports = {
+export default {
   entry: "./src/index.js",
   optimization: {
     minimize: true,
   },
   target: "webworker",
   output: {
-    filename: "index.js",
-    path: path.resolve(__dirname, "bin"),
-    libraryTarget: "this",
+    filename: 'index.cjs',
+    path: path.resolve(import.meta.dirname, "bin"),
+    chunkFormat: 'commonjs',
+    library: {
+      type: 'commonjs',
+    },
   },
   module: {
     // Loaders go here.
@@ -27,11 +30,8 @@ module.exports = {
     }),
   ],
   externals: [
-    ({request,}, callback) => {
-      if (/^fastly:.*$/.test(request)) {
-        return callback(null, 'commonjs ' + request);
-      }
-      callback();
-    }
+    // Allow webpack to handle 'fastly:*' namespaced module imports by treating
+    // them as modules rather than trying to process them as URLs
+    /^fastly:.*$/,
   ],
 };


### PR DESCRIPTION
This PR makes package.json consistent across the various JavaScript (TypeScript) starter kits.

1. As this is a template, removes fields that we would not want downstream projects to inherit if they were set:
   * package name, author, bugs, homepage, repository, license, version

2. As the package created from the template is an application:
   * sets private: true
   * removes main if it was set

3. Removes any engine requirement, as it is unneeded (and has been removed from js-compute since 3.14.0 as well).

4. Updates @fastly/cli to version ^11.0.0 (latest major release) and @fastly/js-compute to ^3.33.2 (includes latest crash fix)
   * if package depends on webpack, updates it to ^5.98.0, which includes a security fix

5. Places `dependencies`, `devDependencies`, `scripts` consistently in this order.
